### PR TITLE
Crawler task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ capybara-*.html
 *.orig
 rerun.txt
 pickle-email-*.html
+.DS_Store
 
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb

--- a/Gemfile
+++ b/Gemfile
@@ -68,3 +68,5 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem "bootstrap", ">= 4.3.1"
 gem 'dotenv-rails'
 gem 'jquery-rails'
+# clawler（HTMLからstringを取得）
+gem 'nokogiri'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,8 @@ gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
-gem 'therubyracer', platforms: :ruby
+# gem 'therubyracer', platforms: :ruby
+gem 'mini_racer', platforms: :ruby
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,7 @@ DEPENDENCIES
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
+  nokogiri
   puma (~> 3.11)
   rails (~> 5.2.2)
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    libv8 (3.16.14.19)
+    libv8 (6.7.288.46.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -117,6 +117,8 @@ GEM
     mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
+    mini_racer (0.2.4)
+      libv8 (>= 6.3)
     minitest (5.11.3)
     msgpack (1.2.7)
     multi_json (1.13.1)
@@ -164,7 +166,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    ref (2.0.0)
     regexp_parser (1.3.0)
     rubocop (0.65.0)
       jaro_winkler (~> 1.5.1)
@@ -213,9 +214,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -252,6 +250,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  mini_racer
   mysql2 (>= 0.4.4, < 0.6.0)
   nokogiri
   puma (~> 3.11)
@@ -261,7 +260,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  therubyracer
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/hotline/categories.coffee
+++ b/app/assets/javascripts/hotline/categories.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/hotline/services.coffee
+++ b/app/assets/javascripts/hotline/services.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/hotline/categories.scss
+++ b/app/assets/stylesheets/hotline/categories.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the hotline/categories controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/hotline/services.scss
+++ b/app/assets/stylesheets/hotline/services.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the hotline/services controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,84 @@
+body {
+  background-color: #fff;
+  color: #333;
+  margin: 33px;
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px;
+}
+
+a {
+  color: #000;
+
+  &:visited {
+    color: #666;
+  }
+
+  &:hover {
+    color: #fff;
+    background-color: #000;
+  }
+}
+
+th {
+  padding-bottom: 5px;
+}
+
+td {
+  padding: 0 5px 7px;
+}
+
+div {
+  &.field, &.actions {
+    margin-bottom: 10px;
+  }
+}
+
+#notice {
+  color: green;
+}
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px 7px 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0;
+
+  h2 {
+    text-align: left;
+    font-weight: bold;
+    padding: 5px 5px 5px 15px;
+    font-size: 12px;
+    margin: -7px -7px 0;
+    background-color: #c00;
+    color: #fff;
+  }
+
+  ul li {
+    font-size: 12px;
+    list-style: square;
+  }
+}
+
+label {
+  display: block;
+}

--- a/app/controllers/hotline/categories_controller.rb
+++ b/app/controllers/hotline/categories_controller.rb
@@ -1,0 +1,74 @@
+class Hotline::CategoriesController < ApplicationController
+  before_action :set_hotline_category, only: [:show, :edit, :update, :destroy]
+
+  # GET /hotline/categories
+  # GET /hotline/categories.json
+  def index
+    @hotline_categories = Hotline::Category.all
+  end
+
+  # GET /hotline/categories/1
+  # GET /hotline/categories/1.json
+  def show
+  end
+
+  # GET /hotline/categories/new
+  def new
+    @hotline_category = Hotline::Category.new
+  end
+
+  # GET /hotline/categories/1/edit
+  def edit
+  end
+
+  # POST /hotline/categories
+  # POST /hotline/categories.json
+  def create
+    @hotline_category = Hotline::Category.new(hotline_category_params)
+
+    respond_to do |format|
+      if @hotline_category.save
+        format.html { redirect_to @hotline_category, notice: 'Category was successfully created.' }
+        format.json { render :show, status: :created, location: @hotline_category }
+      else
+        format.html { render :new }
+        format.json { render json: @hotline_category.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /hotline/categories/1
+  # PATCH/PUT /hotline/categories/1.json
+  def update
+    respond_to do |format|
+      if @hotline_category.update(hotline_category_params)
+        format.html { redirect_to @hotline_category, notice: 'Category was successfully updated.' }
+        format.json { render :show, status: :ok, location: @hotline_category }
+      else
+        format.html { render :edit }
+        format.json { render json: @hotline_category.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /hotline/categories/1
+  # DELETE /hotline/categories/1.json
+  def destroy
+    @hotline_category.destroy
+    respond_to do |format|
+      format.html { redirect_to hotline_categories_url, notice: 'Category was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_hotline_category
+      @hotline_category = Hotline::Category.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def hotline_category_params
+      params.require(:hotline_category).permit(:href, :name, :parent_id)
+    end
+end

--- a/app/controllers/hotline/services_controller.rb
+++ b/app/controllers/hotline/services_controller.rb
@@ -1,0 +1,74 @@
+class Hotline::ServicesController < ApplicationController
+  before_action :set_hotline_service, only: [:show, :edit, :update, :destroy]
+
+  # GET /hotline/services
+  # GET /hotline/services.json
+  def index
+    @hotline_services = Hotline::Service.all
+  end
+
+  # GET /hotline/services/1
+  # GET /hotline/services/1.json
+  def show
+  end
+
+  # GET /hotline/services/new
+  def new
+    @hotline_service = Hotline::Service.new
+  end
+
+  # GET /hotline/services/1/edit
+  def edit
+  end
+
+  # POST /hotline/services
+  # POST /hotline/services.json
+  def create
+    @hotline_service = Hotline::Service.new(hotline_service_params)
+
+    respond_to do |format|
+      if @hotline_service.save
+        format.html { redirect_to @hotline_service, notice: 'Service was successfully created.' }
+        format.json { render :show, status: :created, location: @hotline_service }
+      else
+        format.html { render :new }
+        format.json { render json: @hotline_service.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /hotline/services/1
+  # PATCH/PUT /hotline/services/1.json
+  def update
+    respond_to do |format|
+      if @hotline_service.update(hotline_service_params)
+        format.html { redirect_to @hotline_service, notice: 'Service was successfully updated.' }
+        format.json { render :show, status: :ok, location: @hotline_service }
+      else
+        format.html { render :edit }
+        format.json { render json: @hotline_service.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /hotline/services/1
+  # DELETE /hotline/services/1.json
+  def destroy
+    @hotline_service.destroy
+    respond_to do |format|
+      format.html { redirect_to hotline_services_url, notice: 'Service was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_hotline_service
+      @hotline_service = Hotline::Service.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def hotline_service_params
+      params.require(:hotline_service).permit(:href, :category_id, :value)
+    end
+end

--- a/app/helpers/hotline/categories_helper.rb
+++ b/app/helpers/hotline/categories_helper.rb
@@ -1,0 +1,2 @@
+module Hotline::CategoriesHelper
+end

--- a/app/helpers/hotline/services_helper.rb
+++ b/app/helpers/hotline/services_helper.rb
@@ -1,0 +1,2 @@
+module Hotline::ServicesHelper
+end

--- a/app/models/hotline.rb
+++ b/app/models/hotline.rb
@@ -1,0 +1,5 @@
+module Hotline
+  def self.table_name_prefix
+    'hotline_'
+  end
+end

--- a/app/models/hotline/category.rb
+++ b/app/models/hotline/category.rb
@@ -1,0 +1,7 @@
+class Hotline::Category < ApplicationRecord
+  has_many :children, class_name: 'Hotline::Category', foreign_key: 'parent_id', dependent: :destroy
+  belongs_to :parent, class_name: 'Hotline::Category', optional: true
+  has_many :services
+
+  validates :href, presence: true, uniqueness: { message: 'no_uniqu' }
+end

--- a/app/models/hotline/service.rb
+++ b/app/models/hotline/service.rb
@@ -1,0 +1,4 @@
+class Hotline::Service < ApplicationRecord
+  belongs_to :category,class_name: 'Hotline::Category'
+  validates :href, presence: true, uniqueness: { message: 'no_uniqu' }
+end

--- a/app/views/hotline/categories/_form.html.erb
+++ b/app/views/hotline/categories/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: hotline_category, local: true) do |form| %>
+  <% if hotline_category.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(hotline_category.errors.count, "error") %> prohibited this hotline_category from being saved:</h2>
+
+      <ul>
+      <% hotline_category.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :href %>
+    <%= form.text_field :href %>
+  </div>
+
+  <div class="field">
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :parent_id %>
+    <%= form.text_field :parent_id %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/hotline/categories/_hotline_category.json.jbuilder
+++ b/app/views/hotline/categories/_hotline_category.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! hotline_category, :id, :href, :name, :parent_id, :created_at, :updated_at
+json.url hotline_category_url(hotline_category, format: :json)

--- a/app/views/hotline/categories/edit.html.erb
+++ b/app/views/hotline/categories/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Hotline Category</h1>
+
+<%= render 'form', hotline_category: @hotline_category %>
+
+<%= link_to 'Show', @hotline_category %> |
+<%= link_to 'Back', hotline_categories_path %>

--- a/app/views/hotline/categories/index.html.erb
+++ b/app/views/hotline/categories/index.html.erb
@@ -1,0 +1,31 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Hotline Categories</h1>
+
+<table class='table'>
+  <thead>
+    <tr>
+      <th>Href</th>
+      <th>Name</th>
+      <th>Parent</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @hotline_categories.each do |hotline_category| %>
+      <tr>
+        <td><%= hotline_category.href %></td>
+        <td><%= hotline_category.name %></td>
+        <td><%= hotline_category.parent_id %></td>
+        <td><%= link_to 'Show', hotline_category %></td>
+        <td><%= link_to 'Edit', edit_hotline_category_path(hotline_category) %></td>
+        <td><%= link_to 'Destroy', hotline_category, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Hotline Category', new_hotline_category_path %>

--- a/app/views/hotline/categories/index.json.jbuilder
+++ b/app/views/hotline/categories/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @hotline_categories, partial: 'hotline_categories/hotline_category', as: :hotline_category

--- a/app/views/hotline/categories/new.html.erb
+++ b/app/views/hotline/categories/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Hotline Category</h1>
+
+<%= render 'form', hotline_category: @hotline_category %>
+
+<%= link_to 'Back', hotline_categories_path %>

--- a/app/views/hotline/categories/show.html.erb
+++ b/app/views/hotline/categories/show.html.erb
@@ -1,0 +1,19 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Href:</strong>
+  <%= @hotline_category.href %>
+</p>
+
+<p>
+  <strong>Name:</strong>
+  <%= @hotline_category.name %>
+</p>
+
+<p>
+  <strong>Parent:</strong>
+  <%= @hotline_category.parent_id %>
+</p>
+
+<%= link_to 'Edit', edit_hotline_category_path(@hotline_category) %> |
+<%= link_to 'Back', hotline_categories_path %>

--- a/app/views/hotline/categories/show.json.jbuilder
+++ b/app/views/hotline/categories/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "hotline_categories/hotline_category", hotline_category: @hotline_category

--- a/app/views/hotline/services/_form.html.erb
+++ b/app/views/hotline/services/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: hotline_service, local: true) do |form| %>
+  <% if hotline_service.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(hotline_service.errors.count, "error") %> prohibited this hotline_service from being saved:</h2>
+
+      <ul>
+      <% hotline_service.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :href %>
+    <%= form.text_field :href %>
+  </div>
+
+  <div class="field">
+    <%= form.label :category_id %>
+    <%= form.text_field :category_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :value %>
+    <%= form.text_field :value %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/hotline/services/_hotline_service.json.jbuilder
+++ b/app/views/hotline/services/_hotline_service.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! hotline_service, :id, :href, :category_id, :value, :created_at, :updated_at
+json.url hotline_service_url(hotline_service, format: :json)

--- a/app/views/hotline/services/edit.html.erb
+++ b/app/views/hotline/services/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Hotline Service</h1>
+
+<%= render 'form', hotline_service: @hotline_service %>
+
+<%= link_to 'Show', @hotline_service %> |
+<%= link_to 'Back', hotline_services_path %>

--- a/app/views/hotline/services/index.html.erb
+++ b/app/views/hotline/services/index.html.erb
@@ -1,0 +1,31 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Hotline Services</h1>
+
+<table>
+  <thead class='table'>
+    <tr>
+      <th>Href</th>
+      <th>Category</th>
+      <th>Value</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @hotline_services.each do |hotline_service| %>
+      <tr>
+        <td><%= hotline_service.href %></td>
+        <td><%= hotline_service.category_id %></td>
+        <td><%= hotline_service.value %></td>
+        <td><%= link_to 'Show', hotline_service %></td>
+        <td><%= link_to 'Edit', edit_hotline_service_path(hotline_service) %></td>
+        <td><%= link_to 'Destroy', hotline_service, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Hotline Service', new_hotline_service_path %>

--- a/app/views/hotline/services/index.json.jbuilder
+++ b/app/views/hotline/services/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @hotline_services, partial: 'hotline_services/hotline_service', as: :hotline_service

--- a/app/views/hotline/services/new.html.erb
+++ b/app/views/hotline/services/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Hotline Service</h1>
+
+<%= render 'form', hotline_service: @hotline_service %>
+
+<%= link_to 'Back', hotline_services_path %>

--- a/app/views/hotline/services/show.html.erb
+++ b/app/views/hotline/services/show.html.erb
@@ -1,0 +1,19 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Href:</strong>
+  <%= @hotline_service.href %>
+</p>
+
+<p>
+  <strong>Category:</strong>
+  <%= @hotline_service.category_id %>
+</p>
+
+<p>
+  <strong>Value:</strong>
+  <%= @hotline_service.value %>
+</p>
+
+<%= link_to 'Edit', edit_hotline_service_path(@hotline_service) %> |
+<%= link_to 'Back', hotline_services_path %>

--- a/app/views/hotline/services/show.json.jbuilder
+++ b/app/views/hotline/services/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "hotline_services/hotline_service", hotline_service: @hotline_service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  namespace :hotline do
+    resources :services
+  end
+  namespace :hotline do
+    resources :categories
+  end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20190320122749_create_hotline_categories.rb
+++ b/db/migrate/20190320122749_create_hotline_categories.rb
@@ -1,0 +1,11 @@
+class CreateHotlineCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :hotline_categories do |t|
+      t.string :href
+      t.string :name
+      t.bigint :parent_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190320122857_create_hotline_services.rb
+++ b/db/migrate/20190320122857_create_hotline_services.rb
@@ -1,0 +1,11 @@
+class CreateHotlineServices < ActiveRecord::Migration[5.2]
+  def change
+    create_table :hotline_services do |t|
+      t.string :href
+      t.bigint :category_id
+      t.string :value
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190320122857_create_hotline_services.rb
+++ b/db/migrate/20190320122857_create_hotline_services.rb
@@ -3,7 +3,7 @@ class CreateHotlineServices < ActiveRecord::Migration[5.2]
     create_table :hotline_services do |t|
       t.string :href
       t.bigint :category_id
-      t.string :value
+      t.text :value
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,31 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_03_20_122857) do
+
+  create_table "hotline_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "href"
+    t.string "name"
+    t.bigint "parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "hotline_services", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "href"
+    t.bigint "category_id"
+    t.text "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/lib/tasks/hotline.rake
+++ b/lib/tasks/hotline.rake
@@ -1,23 +1,25 @@
+# frozen_string_literal: true
+
 # カテゴリーのDB更新
 def refresh_href_category
-  host = "https://hotlines.shop/"
-  all_category = Nokogiri::HTML(open(host + "category/"), nil, "utf-8")
+  host = 'https://hotlines.shop/'
+  all_category = Nokogiri::HTML(open(host + 'category/'), nil, 'utf-8')
   p '----------'
 
   all_category.xpath("//ul[@class='category-list list-unstyled']/li").each do |li|
-    item_parent = li.xpath("p[@class='child-category']").css("a").first
-    pp "href:#{item_parent["href"]},name:#{item_parent.content}"
+    item_parent = li.xpath("p[@class='child-category']").css('a').first
+    pp "href:#{item_parent['href']},name:#{item_parent.content}"
 
     Hotline::Category.transaction do
       parent = nil
-      if(Hotline::Category.exists?(href: item_parent["href"]))
-        parent = Hotline::Category.find_by(href: item_parent["href"])
+      if Hotline::Category.exists?(href: item_parent['href'])
+        parent = Hotline::Category.find_by(href: item_parent['href'])
       else
-        parent = Hotline::Category.create!(href: item_parent["href"], name: item_parent.content)
+        parent = Hotline::Category.create!(href: item_parent['href'], name: item_parent.content)
       end
       li.xpath("ul[@class='type-list']/li/a").each do |item_child|
-        unless(Hotline::Category.exists?(href: item_child["href"]))
-          Hotline::Category.create!(href: item_child["href"], name: item_child.content, parent_id: parent.id)
+        unless Hotline::Category.exists?(href: item_child['href'])
+          Hotline::Category.create!(href: item_child['href'], name: item_child.content, parent_id: parent.id)
         end
       end
     end
@@ -26,39 +28,40 @@ end
 
 # サービスのDB（uri）更新
 def refresh_href_service
-  host = "https://hotlines.shop/"
+  host = 'https://hotlines.shop/'
   Hotline::Category.all.each do |category|
     next unless category.children.empty?
+
     url = URI.join(host, category.href)
     pp '----------'
     pp "category:#{category.name}"
 
     max = 1
-    category_page = Nokogiri::HTML(open(url), nil, "utf-8")
-    if category_page.css("ul.pagination-list").present?
-      max = category_page.css("ul.pagination-list > li > a").last["href"]
-      max&.slice!("././?page=")
+    category_page = Nokogiri::HTML(open(url), nil, 'utf-8')
+    if category_page.css('ul.pagination-list').present?
+      max = category_page.css('ul.pagination-list > li > a').last['href']
+      max&.slice!('././?page=')
       max = max.to_i
     end
 
     count1 = 0
     count2 = 0
     1.upto(max) do |page_num|
-      url.query = {page: page_num}.to_param
-      page = Nokogiri::HTML(open(url), nil, "utf-8")
+      url.query = { page: page_num }.to_param
+      page = Nokogiri::HTML(open(url), nil, 'utf-8')
       page.css('.link_box > a').each do |service_link|
         count1 += 1
-        href = service_link["href"].split("/").last + "/"
+        href = service_link['href'].split('/').last + '/'
         # pp "#{(count1 + count2).to_s}:#{service_link["href"]}"
         Hotline::Service.transaction do
-          unless (Hotline::Service.exists?(href: href))
+          unless Hotline::Service.exists?(href: href)
             Hotline::Service.create!(href: href, category_id: category.id)
           end
         end
       end
 
       # 準備中のサービス
-      page.css('.nolink_box').each do |service_link|
+      page.css('.nolink_box').each do |_service_link|
         count2 += 1
         # pp (count1 + count2).to_s + ":" + "nolink"
       end
@@ -72,24 +75,24 @@ end
 
 # DBのサービス（uri）からデータ取得
 # 主な取得データ"[\"店長\",\"所在地\",\"営業時間\",\"定 休 日\",\"対応地域\",\"電話番号\",\"WEB\"]"
-def update_service service:
-  host = "https://hotlines.shop/"
+def update_service(service:)
+  host = 'https://hotlines.shop/'
   url = URI.join(host, service.category.href).to_s
   url = URI.join(url, service.href).to_s
   p url
-  service_page = Nokogiri::HTML(open(url), nil, "utf-8")
+  service_page = Nokogiri::HTML(open(url), nil, 'utf-8')
   store = service_page.xpath("//div[@class='store-details-wrap']")
   service_map = {}
   count = 0
-  store.xpath(".//tr").each do |tr|
+  store.xpath('.//tr').each do |tr|
     count += 1
     th = '', td = ''
-    if(count == 1)
+    if count == 1
       th = '店長'
-      td = tr.xpath(".//td").first.xpath(".//p").first.content.split("：").last
+      td = tr.xpath('.//td').first.xpath('.//p').first.content.split('：').last
     else
-      th = tr.css("th").first.content.gsub(/[[:cntrl:]]/,'')
-      td = tr.css("td").first.content.gsub(/[[:cntrl:]]/,'')
+      th = tr.css('th').first.content.gsub(/[[:cntrl:]]/, '')
+      td = tr.css('td').first.content.gsub(/[[:cntrl:]]/, '')
     end
     service_map[th] = td
   end
@@ -97,16 +100,16 @@ def update_service service:
     service.value = service_map.to_json
     service.save
   end
-  return service_map
+  service_map
   # pp service.xpath("//div[@class='shoptable']").first.css("p").inner_html
 end
 
 namespace :hotline do
-  desc "hotlineのDB全体更新"
-  task :all_update => :environment do
+  desc 'hotlineのDB全体更新'
+  task all_update: :environment do
     refresh_href_category
     refresh_href_service
-    pp "------------"
+    pp '------------'
     count = 0
     Hotline::Service.all.each do |service|
       count += 1
@@ -115,8 +118,11 @@ namespace :hotline do
     end
   end
 
-  desc "サービスidからjsonデータ更新"
-  task :service_update, [:service_id] => :environment do |task, args|
-    print update_service service: Hotline::Service.find(args[:service_id])
+  desc 'サービスidからjsonデータ更新'
+  task :service_update, %i[service_id limit] => :environment do |_task, args|
+    services = Hotline::Service.where('id >= ?', args[:service_id]).limit(args[:limit])
+    services.each do |service|
+      print "#{service.id}:#{update_service service: service}"
+    end
   end
 end

--- a/lib/tasks/hotline.rake
+++ b/lib/tasks/hotline.rake
@@ -1,0 +1,122 @@
+# カテゴリーのDB更新
+def refresh_href_category
+  host = "https://hotlines.shop/"
+  all_category = Nokogiri::HTML(open(host + "category/"), nil, "utf-8")
+  p '----------'
+
+  all_category.xpath("//ul[@class='category-list list-unstyled']/li").each do |li|
+    item_parent = li.xpath("p[@class='child-category']").css("a").first
+    pp "href:#{item_parent["href"]},name:#{item_parent.content}"
+
+    Hotline::Category.transaction do
+      parent = nil
+      if(Hotline::Category.exists?(href: item_parent["href"]))
+        parent = Hotline::Category.find_by(href: item_parent["href"])
+      else
+        parent = Hotline::Category.create!(href: item_parent["href"], name: item_parent.content)
+      end
+      li.xpath("ul[@class='type-list']/li/a").each do |item_child|
+        unless(Hotline::Category.exists?(href: item_child["href"]))
+          Hotline::Category.create!(href: item_child["href"], name: item_child.content, parent_id: parent.id)
+        end
+      end
+    end
+  end
+end
+
+# サービスのDB（uri）更新
+def refresh_href_service
+  host = "https://hotlines.shop/"
+  Hotline::Category.all.each do |category|
+    next unless category.children.empty?
+    url = URI.join(host, category.href)
+    pp '----------'
+    pp "category:#{category.name}"
+
+    max = 1
+    category_page = Nokogiri::HTML(open(url), nil, "utf-8")
+    if category_page.css("ul.pagination-list").present?
+      max = category_page.css("ul.pagination-list > li > a").last["href"]
+      max&.slice!("././?page=")
+      max = max.to_i
+    end
+
+    count1 = 0
+    count2 = 0
+    1.upto(max) do |page_num|
+      url.query = {page: page_num}.to_param
+      page = Nokogiri::HTML(open(url), nil, "utf-8")
+      page.css('.link_box > a').each do |service_link|
+        count1 += 1
+        href = service_link["href"].split("/").last + "/"
+        # pp "#{(count1 + count2).to_s}:#{service_link["href"]}"
+        Hotline::Service.transaction do
+          unless (Hotline::Service.exists?(href: href))
+            Hotline::Service.create!(href: href, category_id: category.id)
+          end
+        end
+      end
+
+      # 準備中のサービス
+      page.css('.nolink_box').each do |service_link|
+        count2 += 1
+        # pp (count1 + count2).to_s + ":" + "nolink"
+      end
+    end
+
+    pp "active:#{count1}"
+    pp "unactive:#{count2}"
+    pp "all:#{count1 + count2}"
+  end
+end
+
+# DBのサービス（uri）からデータ取得
+# 主な取得データ"[\"店長\",\"所在地\",\"営業時間\",\"定 休 日\",\"対応地域\",\"電話番号\",\"WEB\"]"
+def update_service service:
+  host = "https://hotlines.shop/"
+  url = URI.join(host, service.category.href).to_s
+  url = URI.join(url, service.href).to_s
+  p url
+  service_page = Nokogiri::HTML(open(url), nil, "utf-8")
+  store = service_page.xpath("//div[@class='store-details-wrap']")
+  service_map = {}
+  count = 0
+  store.xpath(".//tr").each do |tr|
+    count += 1
+    th = '', td = ''
+    if(count == 1)
+      th = '店長'
+      td = tr.xpath(".//td").first.xpath(".//p").first.content.split("：").last
+    else
+      th = tr.css("th").first.content.gsub(/[[:cntrl:]]/,'')
+      td = tr.css("td").first.content.gsub(/[[:cntrl:]]/,'')
+    end
+    service_map[th] = td
+  end
+  Hotline::Service.transaction do
+    service.value = service_map.to_json
+    service.save
+  end
+  return service_map
+  # pp service.xpath("//div[@class='shoptable']").first.css("p").inner_html
+end
+
+namespace :hotline do
+  desc "hotlineのDB全体更新"
+  task :all_update => :environment do
+    refresh_href_category
+    refresh_href_service
+    pp "------------"
+    count = 0
+    Hotline::Service.all.each do |service|
+      count += 1
+      p count
+      update_service service: service
+    end
+  end
+
+  desc "サービスidからjsonデータ更新"
+  task :service_update, [:service_id] => :environment do |task, args|
+    print update_service service: Hotline::Service.find(args[:service_id])
+  end
+end

--- a/test/controllers/hotline/categories_controller_test.rb
+++ b/test/controllers/hotline/categories_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class Hotline::CategoriesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @hotline_category = hotline_categories(:one)
+  end
+
+  test "should get index" do
+    get hotline_categories_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_hotline_category_url
+    assert_response :success
+  end
+
+  test "should create hotline_category" do
+    assert_difference('Hotline::Category.count') do
+      post hotline_categories_url, params: { hotline_category: { href: @hotline_category.href, name: @hotline_category.name, parent_id: @hotline_category.parent_id } }
+    end
+
+    assert_redirected_to hotline_category_url(Hotline::Category.last)
+  end
+
+  test "should show hotline_category" do
+    get hotline_category_url(@hotline_category)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_hotline_category_url(@hotline_category)
+    assert_response :success
+  end
+
+  test "should update hotline_category" do
+    patch hotline_category_url(@hotline_category), params: { hotline_category: { href: @hotline_category.href, name: @hotline_category.name, parent_id: @hotline_category.parent_id } }
+    assert_redirected_to hotline_category_url(@hotline_category)
+  end
+
+  test "should destroy hotline_category" do
+    assert_difference('Hotline::Category.count', -1) do
+      delete hotline_category_url(@hotline_category)
+    end
+
+    assert_redirected_to hotline_categories_url
+  end
+end

--- a/test/controllers/hotline/services_controller_test.rb
+++ b/test/controllers/hotline/services_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class Hotline::ServicesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @hotline_service = hotline_services(:one)
+  end
+
+  test "should get index" do
+    get hotline_services_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_hotline_service_url
+    assert_response :success
+  end
+
+  test "should create hotline_service" do
+    assert_difference('Hotline::Service.count') do
+      post hotline_services_url, params: { hotline_service: { category_id: @hotline_service.category_id, href: @hotline_service.href, value: @hotline_service.value } }
+    end
+
+    assert_redirected_to hotline_service_url(Hotline::Service.last)
+  end
+
+  test "should show hotline_service" do
+    get hotline_service_url(@hotline_service)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_hotline_service_url(@hotline_service)
+    assert_response :success
+  end
+
+  test "should update hotline_service" do
+    patch hotline_service_url(@hotline_service), params: { hotline_service: { category_id: @hotline_service.category_id, href: @hotline_service.href, value: @hotline_service.value } }
+    assert_redirected_to hotline_service_url(@hotline_service)
+  end
+
+  test "should destroy hotline_service" do
+    assert_difference('Hotline::Service.count', -1) do
+      delete hotline_service_url(@hotline_service)
+    end
+
+    assert_redirected_to hotline_services_url
+  end
+end

--- a/test/fixtures/hotline/categories.yml
+++ b/test/fixtures/hotline/categories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  href: MyString
+  name: MyString
+  parent_id: 
+
+two:
+  href: MyString
+  name: MyString
+  parent_id: 

--- a/test/fixtures/hotline/services.yml
+++ b/test/fixtures/hotline/services.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  href: MyString
+  category_id: 
+  value: MyString
+
+two:
+  href: MyString
+  category_id: 
+  value: MyString

--- a/test/models/hotline/category_test.rb
+++ b/test/models/hotline/category_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Hotline::CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/hotline/service_test.rb
+++ b/test/models/hotline/service_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Hotline::ServiceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/hotline/categories_test.rb
+++ b/test/system/hotline/categories_test.rb
@@ -1,0 +1,47 @@
+require "application_system_test_case"
+
+class Hotline::CategoriesTest < ApplicationSystemTestCase
+  setup do
+    @hotline_category = hotline_categories(:one)
+  end
+
+  test "visiting the index" do
+    visit hotline_categories_url
+    assert_selector "h1", text: "Hotline/Categories"
+  end
+
+  test "creating a Category" do
+    visit hotline_categories_url
+    click_on "New Hotline/Category"
+
+    fill_in "Href", with: @hotline_category.href
+    fill_in "Name", with: @hotline_category.name
+    fill_in "Parent", with: @hotline_category.parent_id
+    click_on "Create Category"
+
+    assert_text "Category was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Category" do
+    visit hotline_categories_url
+    click_on "Edit", match: :first
+
+    fill_in "Href", with: @hotline_category.href
+    fill_in "Name", with: @hotline_category.name
+    fill_in "Parent", with: @hotline_category.parent_id
+    click_on "Update Category"
+
+    assert_text "Category was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Category" do
+    visit hotline_categories_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Category was successfully destroyed"
+  end
+end

--- a/test/system/hotline/services_test.rb
+++ b/test/system/hotline/services_test.rb
@@ -1,0 +1,47 @@
+require "application_system_test_case"
+
+class Hotline::ServicesTest < ApplicationSystemTestCase
+  setup do
+    @hotline_service = hotline_services(:one)
+  end
+
+  test "visiting the index" do
+    visit hotline_services_url
+    assert_selector "h1", text: "Hotline/Services"
+  end
+
+  test "creating a Service" do
+    visit hotline_services_url
+    click_on "New Hotline/Service"
+
+    fill_in "Category", with: @hotline_service.category_id
+    fill_in "Href", with: @hotline_service.href
+    fill_in "Value", with: @hotline_service.value
+    click_on "Create Service"
+
+    assert_text "Service was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Service" do
+    visit hotline_services_url
+    click_on "Edit", match: :first
+
+    fill_in "Category", with: @hotline_service.category_id
+    fill_in "Href", with: @hotline_service.href
+    fill_in "Value", with: @hotline_service.value
+    click_on "Update Service"
+
+    assert_text "Service was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Service" do
+    visit hotline_services_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Service was successfully destroyed"
+  end
+end


### PR DESCRIPTION
**概要**
[Hotline](https://hotlines.shop/)のクローラー作成
　サービス詳細ページの「この店舗について」の部分を
　jsonで保存しました。

**内容**
rake taskで実装 `lib/tasks/hotline.rake`
　全サービスをクローリングし、DBに保存するものと、
　保存してあるサービスを数件更新する用のものと２つ作成しました。

* `bundle exec rake hotline:all_update`
hotlineのDB全体を更新→現在、3700件ほど更新することになるので少し時間がかかります。
* `bundle exec rake hotline:service_update[#SERVICE_ID,#LIMIT]`
all_updateのあとで、数件のデータを更新したい場合はservice_updateの引数を指定して、
`#SERVICE_ID`から`#LIMIT`件数分のjsonデータを更新できます。

**参考**
[法的注意点](https://qiita.com/nezuq/items/3cc9772118ad112c18dc)
[スクレイピング注意点](https://qiita.com/nezuq/items/c5e827e1827e7cb29011)